### PR TITLE
Expose the port from the Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:trusty
 
+EXPOSE 8075
+
 # verify gpg and sha256: http://nodejs.org/dist/v0.10.30/SHASUMS256.txt.asc
 # gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"
 # gpg: aka "Julien Gilli <jgilli@fastmail.fm>"


### PR DESCRIPTION
Little edit so the port 8075 is exposed from the container.
This is really useful when used with https://github.com/jwilder/nginx-proxy.