### PR TITLE
Switch to Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,8 @@
 # From the official nodejs image, based on Debian Jessy
-FROM node:7
+FROM node:7-alpine
 
-# Add the jessy-backports repository, to install the true FFmpeg library
-RUN awk '$1 ~ "^deb" { $3 = $3 "-backports"; print; exit }' /etc/apt/sources.list > /etc/apt/sources.list.d/backports.list
-
-# Install ffmpeg and graphicsmagick
-RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
-    graphicsmagick ffmpeg \
-    && rm -rf /var/lib/apt/lists/*
+# Install ffmpeg and imagemagick
+RUN apk --no-cache add ffmpeg imagemagick git
 
 # Building
 RUN mkdir -p /usr/src/app

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Return the file :-)
 ## Behind
 
  * [NodeJs](http://nodejs.org/)
- * [GraphicsMagick](http://www.graphicsmagick.org/) with [gm](http://aheckmann.github.io/gm/)
+ * [GraphicsMagick](http://www.graphicsmagick.org/) or [ImageMagick](https://www.imagemagick.org/) with [gm](http://aheckmann.github.io/gm/)
  * [FFmpeg](https://www.ffmpeg.org/) with [node-fluent-ffmpeg](https://github.com/fluent-ffmpeg/node-fluent-ffmpeg)
  * [Express](http://expressjs.com/)
  * [Bootstrap](http://getbootstrap.com)


### PR DESCRIPTION
Switching to Alpine Linux allows us to reduce the image size from 933 MB to 259 MB.
The only drawback being having to use ImageMagick until Node switches to Alpine 3.5 (Probably when Node 8 comes out.)